### PR TITLE
fix: set fsgroup as same as mattermost

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -20,6 +20,8 @@ spec:
       labels:
         app: mattermost
     spec:
+      securityContext: 
+        fsGroup: 2000
       serviceAccountName: mattermost-primary
       initContainers:
         - name: secret-placer


### PR DESCRIPTION
- 確認したところマウント自体はrw可でできているようでした
```
(ry)
    Mounts:
      /mattermost/bleve/ from bleve-cache (rw)
(ry)
Volumes:
(ry)
  bleve-cache:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  mattermost-bleve-pvc
    ReadOnly:   false
(ry)
```

- [mattermostのイメージ](https://hub.docker.com/layers/mattermost/mattermost-team-edition/release-9.1/images/sha256-0089857fba531a19eb716960e572a2f59ce64142267b94da2c8371863a1205be?context=explore)を確認したところmattermostを動かしているのは`mattermost(2000):mattermost(2000)`でした
 
これらのことから、おそらくユーザーが違うために書き込めないのだろうという結論になったため、fsGroupにmattermostの2000番を指定することで対応しました
```
      securityContext: 
        fsGroup: 2000
```


