### PR TITLE
fix: change config owner to mattermost

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -29,7 +29,7 @@ spec:
           command: ["/bin/sh","-c"]
           args:
             - gcloud kms decrypt --location asia-northeast1 --keyring primary-keyring --key primary-key --ciphertext-file=/secret/config.json --plaintext-file=/config/config.json
-              && chmod o+w /config/config.json
+              && chown 2000:2000 /config/config.json
           volumeMounts:
             - name: config
               mountPath: /config


### PR DESCRIPTION
- config.jsonに書き込み権限がなく、落ちていた
- fsGroupを設定した際に落ちるようになったため、所有者関連が原因の可能性が高い
- 近い構成を手元に作り、同じエラーを再現したところ、このPRの差分でエラーが解決できた