### PR TITLE
hotfix: extend initial delay to 3600s

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -58,7 +58,7 @@ spec:
             path:  /api/v4/system/ping
             port: http
         livenessProbe:
-          initialDelaySeconds: 600
+          initialDelaySeconds: 3600
           timeoutSeconds: 5
           periodSeconds: 15
           failureThreshold: 4

--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -58,7 +58,7 @@ spec:
             path:  /api/v4/system/ping
             port: http
         livenessProbe:
-          initialDelaySeconds: 3600
+          initialDelaySeconds: 600
           timeoutSeconds: 5
           periodSeconds: 15
           failureThreshold: 4

--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -65,6 +65,12 @@ spec:
           httpGet:
             path:  /api/v4/system/ping
             port: http
+        startupProbe:
+          httpGet:
+            path:  /api/v4/system/ping
+            port: http
+          failureThreshold: 360
+          periodSeconds: 10
         volumeMounts:
           - name: config
             mountPath: /mattermost/config/


### PR DESCRIPTION
- 10分間隔で再起動している
- bleveの初期化で詰まっている
![image](https://github.com/mitou/mattermost.jr.mitou.org/assets/96982836/727b6ef0-a60c-4fef-88b2-787ee0fad274)

ことから、インデックスの構成中に`livenessProbe`の`initialDelaySeconds`(10分)を超えて再起動されていると考えられるため、
~~インデックス構成用の仮対応として`initialDelaySeconds`を1時間に延長しています~~
`startupProbe`を追加し、起動時に1時間まで待機するように変更しました