### PR TITLE
 chore: extend startup timeout to 1d 

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -69,7 +69,7 @@ spec:
           httpGet:
             path:  /api/v4/system/ping
             port: http
-          failureThreshold: 360
+          failureThreshold: 8640
           periodSeconds: 10
         volumeMounts:
           - name: config


### PR DESCRIPTION
正直もうヤケクソです

手元で青空文庫のデータを少し流し込んだ状態で試したところ0.1秒ほどで次へ進んだためそこまで時間がかかることもないと思うのですが、
![image](https://github.com/mitou/mattermost.jr.mitou.org/assets/96982836/77fcc0b8-89da-49c4-bab7-dea325ec1749)
bleve初期化中のログが一切無い(ソースコードも確認しましたがなさそう)ため判別が全く付きません

なのでとりあえず初期化のタイムアウトを1日まで伸ばしました