### PR TITLE
fix: add namespace to pdb

### DIFF
--- a/kubernetes/mattermost/pdb.yml
+++ b/kubernetes/mattermost/pdb.yml
@@ -2,6 +2,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: mattermost-pdb
+  namespace: mattermost
 spec:
   minAvailable: 1
   selector:


### PR DESCRIPTION
mattermost 用の pdb が誤って default namespace に配置され、機能していなかったため、 mattermost namespace に移動