### PR TITLE
[修正] external secrets operatorにdeploymentがなかったので修正

### DIFF
--- a/kubernetes/mattermost/external-secrets-operator.yml
+++ b/kubernetes/mattermost/external-secrets-operator.yml
@@ -12266,6 +12266,9 @@ spec:
             requests:
               memory: "512Mi"
               cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -12336,6 +12339,9 @@ spec:
             requests:
               memory: "512Mi"
               cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -12391,6 +12397,9 @@ spec:
         - name: webhook
           resources:
             requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
               memory: "512Mi"
               cpu: "250m"
           securityContext:

--- a/kubernetes/mattermost/external-secrets-operator.yml
+++ b/kubernetes/mattermost/external-secrets-operator.yml
@@ -1,204 +1,254 @@
-  #                                Apache License
-  #                          Version 2.0, January 2004
-  #                       http://www.apache.org/licenses/
+---
+# Source: external-secrets/templates/cert-controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-cert-controller
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: external-secrets/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: external-secrets/templates/webhook-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-webhook
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: external-secrets/templates/webhook-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-secrets-webhook
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+    external-secrets.io/component: webhook
+---
+# Source: external-secrets/templates/crds/acraccesstoken.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: acraccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - acraccesstoken
+    kind: ACRAccessToken
+    listKind: ACRAccessTokenList
+    plural: acraccesstokens
+    shortNames:
+      - acraccesstoken
+    singular: acraccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ACRAccessToken returns a Azure Container Registry token
+            that can be used for pushing/pulling images.
+            Note: by default it will return an ACR Refresh Token with full access
+            (depending on the identity).
+            This can be scoped down to the repository level using .spec.scope.
+            In case scope is defined it will return an ACR Access Token.
 
-  #  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  #  1. Definitions.
+            See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                ACRAccessTokenSpec defines how to generate the access token
+                e.g. how to authenticate and which registry to use.
+                see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview
+              properties:
+                auth:
+                  properties:
+                    managedIdentity:
+                      description: ManagedIdentity uses Azure Managed Identity to authenticate with Azure.
+                      properties:
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                      type: object
+                    servicePrincipal:
+                      description: ServicePrincipal uses Azure Service Principal credentials to authenticate with Azure.
+                      properties:
+                        secretRef:
+                          description: |-
+                            Configuration used to authenticate with Azure using static
+                            credentials stored in a Kind=Secret.
+                          properties:
+                            clientId:
+                              description: The Azure clientId of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                    defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                    to the namespace of the referent.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                    defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                    to the namespace of the referent.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - secretRef
+                      type: object
+                    workloadIdentity:
+                      description: WorkloadIdentity uses Azure Workload Identity to authenticate with Azure.
+                      properties:
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                  type: object
+                environmentType:
+                  default: PublicCloud
+                  description: |-
+                    EnvironmentType specifies the Azure cloud environment endpoints to use for
+                    connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+                    The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                    PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+                  enum:
+                    - PublicCloud
+                    - USGovernmentCloud
+                    - ChinaCloud
+                    - GermanCloud
+                  type: string
+                registry:
+                  description: |-
+                    the domain name of the ACR registry
+                    e.g. foobarexample.azurecr.io
+                  type: string
+                scope:
+                  description: |-
+                    Define the scope for the access token, e.g. pull/push access for a repository.
+                    if not provided it will return a refresh token that has full scope.
+                    Note: you need to pin it down to the repository level, there is no wildcard available.
 
-  #     "License" shall mean the terms and conditions for use, reproduction,
-  #     and distribution as defined by Sections 1 through 9 of this document.
 
-  #     "Licensor" shall mean the copyright owner or entity authorized by
-  #     the copyright owner that is granting the License.
+                    examples:
+                    repository:my-repository:pull,push
+                    repository:my-repository:pull
 
-  #     "Legal Entity" shall mean the union of the acting entity and all
-  #     other entities that control, are controlled by, or are under common
-  #     control with that entity. For the purposes of this definition,
-  #     "control" means (i) the power, direct or indirect, to cause the
-  #     direction or management of such entity, whether by contract or
-  #     otherwise, or (ii) ownership of fifty percent (50%) or more of the
-  #     outstanding shares, or (iii) beneficial ownership of such entity.
 
-  #     "You" (or "Your") shall mean an individual or Legal Entity
-  #     exercising permissions granted by this License.
-
-  #     "Source" form shall mean the preferred form for making modifications,
-  #     including but not limited to software source code, documentation
-  #     source, and configuration files.
-
-  #     "Object" form shall mean any form resulting from mechanical
-  #     transformation or translation of a Source form, including but
-  #     not limited to compiled object code, generated documentation,
-  #     and conversions to other media types.
-
-  #     "Work" shall mean the work of authorship, whether in Source or
-  #     Object form, made available under the License, as indicated by a
-  #     copyright notice that is included in or attached to the work
-  #     (an example is provided in the Appendix below).
-
-  #     "Derivative Works" shall mean any work, whether in Source or Object
-  #     form, that is based on (or derived from) the Work and for which the
-  #     editorial revisions, annotations, elaborations, or other modifications
-  #     represent, as a whole, an original work of authorship. For the purposes
-  #     of this License, Derivative Works shall not include works that remain
-  #     separable from, or merely link (or bind by name) to the interfaces of,
-  #     the Work and Derivative Works thereof.
-
-  #     "Contribution" shall mean any work of authorship, including
-  #     the original version of the Work and any modifications or additions
-  #     to that Work or Derivative Works thereof, that is intentionally
-  #     submitted to Licensor for inclusion in the Work by the copyright owner
-  #     or by an individual or Legal Entity authorized to submit on behalf of
-  #     the copyright owner. For the purposes of this definition, "submitted"
-  #     means any form of electronic, verbal, or written communication sent
-  #     to the Licensor or its representatives, including but not limited to
-  #     communication on electronic mailing lists, source code control systems,
-  #     and issue tracking systems that are managed by, or on behalf of, the
-  #     Licensor for the purpose of discussing and improving the Work, but
-  #     excluding communication that is conspicuously marked or otherwise
-  #     designated in writing by the copyright owner as "Not a Contribution."
-
-  #     "Contributor" shall mean Licensor and any individual or Legal Entity
-  #     on behalf of whom a Contribution has been received by Licensor and
-  #     subsequently incorporated within the Work.
-
-  #  2. Grant of Copyright License. Subject to the terms and conditions of
-  #     this License, each Contributor hereby grants to You a perpetual,
-  #     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-  #     copyright license to reproduce, prepare Derivative Works of,
-  #     publicly display, publicly perform, sublicense, and distribute the
-  #     Work and such Derivative Works in Source or Object form.
-
-  #  3. Grant of Patent License. Subject to the terms and conditions of
-  #     this License, each Contributor hereby grants to You a perpetual,
-  #     worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-  #     (except as stated in this section) patent license to make, have made,
-  #     use, offer to sell, sell, import, and otherwise transfer the Work,
-  #     where such license applies only to those patent claims licensable
-  #     by such Contributor that are necessarily infringed by their
-  #     Contribution(s) alone or by combination of their Contribution(s)
-  #     with the Work to which such Contribution(s) was submitted. If You
-  #     institute patent litigation against any entity (including a
-  #     cross-claim or counterclaim in a lawsuit) alleging that the Work
-  #     or a Contribution incorporated within the Work constitutes direct
-  #     or contributory patent infringement, then any patent licenses
-  #     granted to You under this License for that Work shall terminate
-  #     as of the date such litigation is filed.
-
-  #  4. Redistribution. You may reproduce and distribute copies of the
-  #     Work or Derivative Works thereof in any medium, with or without
-  #     modifications, and in Source or Object form, provided that You
-  #     meet the following conditions:
-
-  #     (a) You must give any other recipients of the Work or
-  #         Derivative Works a copy of this License; and
-
-  #     (b) You must cause any modified files to carry prominent notices
-  #         stating that You changed the files; and
-
-  #     (c) You must retain, in the Source form of any Derivative Works
-  #         that You distribute, all copyright, patent, trademark, and
-  #         attribution notices from the Source form of the Work,
-  #         excluding those notices that do not pertain to any part of
-  #         the Derivative Works; and
-
-  #     (d) If the Work includes a "NOTICE" text file as part of its
-  #         distribution, then any Derivative Works that You distribute must
-  #         include a readable copy of the attribution notices contained
-  #         within such NOTICE file, excluding those notices that do not
-  #         pertain to any part of the Derivative Works, in at least one
-  #         of the following places: within a NOTICE text file distributed
-  #         as part of the Derivative Works; within the Source form or
-  #         documentation, if provided along with the Derivative Works; or,
-  #         within a display generated by the Derivative Works, if and
-  #         wherever such third-party notices normally appear. The contents
-  #         of the NOTICE file are for informational purposes only and
-  #         do not modify the License. You may add Your own attribution
-  #         notices within Derivative Works that You distribute, alongside
-  #         or as an addendum to the NOTICE text from the Work, provided
-  #         that such additional attribution notices cannot be construed
-  #         as modifying the License.
-
-  #     You may add Your own copyright statement to Your modifications and
-  #     may provide additional or different license terms and conditions
-  #     for use, reproduction, or distribution of Your modifications, or
-  #     for any such Derivative Works as a whole, provided Your use,
-  #     reproduction, and distribution of the Work otherwise complies with
-  #     the conditions stated in this License.
-
-  #  5. Submission of Contributions. Unless You explicitly state otherwise,
-  #     any Contribution intentionally submitted for inclusion in the Work
-  #     by You to the Licensor shall be under the terms and conditions of
-  #     this License, without any additional terms or conditions.
-  #     Notwithstanding the above, nothing herein shall supersede or modify
-  #     the terms of any separate license agreement you may have executed
-  #     with Licensor regarding such Contributions.
-
-  #  6. Trademarks. This License does not grant permission to use the trade
-  #     names, trademarks, service marks, or product names of the Licensor,
-  #     except as required for reasonable and customary use in describing the
-  #     origin of the Work and reproducing the content of the NOTICE file.
-
-  #  7. Disclaimer of Warranty. Unless required by applicable law or
-  #     agreed to in writing, Licensor provides the Work (and each
-  #     Contributor provides its Contributions) on an "AS IS" BASIS,
-  #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-  #     implied, including, without limitation, any warranties or conditions
-  #     of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-  #     PARTICULAR PURPOSE. You are solely responsible for determining the
-  #     appropriateness of using or redistributing the Work and assume any
-  #     risks associated with Your exercise of permissions under this License.
-
-  #  8. Limitation of Liability. In no event and under no legal theory,
-  #     whether in tort (including negligence), contract, or otherwise,
-  #     unless required by applicable law (such as deliberate and grossly
-  #     negligent acts) or agreed to in writing, shall any Contributor be
-  #     liable to You for damages, including any direct, indirect, special,
-  #     incidental, or consequential damages of any character arising as a
-  #     result of this License or out of the use or inability to use the
-  #     Work (including but not limited to damages for loss of goodwill,
-  #     work stoppage, computer failure or malfunction, or any and all
-  #     other commercial damages or losses), even if such Contributor
-  #     has been advised of the possibility of such damages.
-
-  #  9. Accepting Warranty or Additional Liability. While redistributing
-  #     the Work or Derivative Works thereof, You may choose to offer,
-  #     and charge a fee for, acceptance of support, warranty, indemnity,
-  #     or other liability obligations and/or rights consistent with this
-  #     License. However, in accepting such obligations, You may act only
-  #     on Your own behalf and on Your sole responsibility, not on behalf
-  #     of any other Contributor, and only if You agree to indemnify,
-  #     defend, and hold each Contributor harmless for any liability
-  #     incurred by, or claims asserted against, such Contributor by reason
-  #     of your accepting any such warranty or additional liability.
-
-  #  END OF TERMS AND CONDITIONS
-
-  #  APPENDIX: How to apply the Apache License to your work.
-
-  #     To apply the Apache License to your work, attach the following
-  #     boilerplate notice, with the fields enclosed by brackets "[]"
-  #     replaced with your own identifying information. (Don't include
-  #     the brackets!)  The text should be enclosed in the appropriate
-  #     comment syntax for the file format. We also recommend that a
-  #     file or class name and description of purpose be included on the
-  #     same "printed page" as the copyright notice for easier
-  #     identification within third-party archives.
-
-  #  Copyright [yyyy] [name of copyright owner]
-
-  #  Licensed under the Apache License, Version 2.0 (the "License");
-  #  you may not use this file except in compliance with the License.
-  #  You may obtain a copy of the License at
-
-  #      http://www.apache.org/licenses/LICENSE-2.0
-
-  #  Unless required by applicable law or agreed to in writing, software
-  #  distributed under the License is distributed on an "AS IS" BASIS,
-  #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  #  See the License for the specific language governing permissions and
-  #  limitations under the License.
+                    see docs for details: https://docs.docker.com/registry/spec/auth/scope/
+                  type: string
+                tenantId:
+                  description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                  type: string
+              required:
+                - auth
+                - registry
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: "default"
+          path: /convert
+---
+# Source: external-secrets/templates/crds/clusterexternalsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -847,10 +897,11 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
 ---
+# Source: external-secrets/templates/crds/clustersecretstore.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5009,10 +5060,178 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
 ---
+# Source: external-secrets/templates/crds/ecrauthorizationtoken.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: ecrauthorizationtokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - ecrauthorizationtoken
+    kind: ECRAuthorizationToken
+    listKind: ECRAuthorizationTokenList
+    plural: ecrauthorizationtokens
+    shortNames:
+      - ecrauthorizationtoken
+    singular: ecrauthorizationtoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ECRAuthorizationTokenSpec uses the GetAuthorizationToken API to retrieve an
+            authorization token.
+            The authorization token is valid for 12 hours.
+            The authorizationToken returned is a base64 encoded string that can be decoded
+            and used in a docker login command to authenticate to a registry.
+            For more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth) in the Amazon Elastic Container Registry User Guide.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                auth:
+                  description: Auth defines how to authenticate with AWS
+                  properties:
+                    jwt:
+                      description: Authenticate against AWS using service account tokens.
+                      properties:
+                        serviceAccountRef:
+                          description: A reference to a ServiceAccount resource.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    secretRef:
+                      description: |-
+                        AWSAuthSecretRef holds secret references for AWS credentials
+                        both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                      properties:
+                        accessKeyIDSecretRef:
+                          description: The AccessKeyID is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          type: object
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          type: object
+                        sessionTokenSecretRef:
+                          description: |-
+                            The SessionToken used for authentication
+                            This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                            see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                region:
+                  description: Region specifies the region to operate in.
+                  type: string
+                role:
+                  description: |-
+                    You can assume a role before making calls to the
+                    desired AWS service.
+                  type: string
+              required:
+                - region
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: "default"
+          path: /convert
+---
+# Source: external-secrets/templates/crds/externalsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5813,10 +6032,415 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
 ---
+# Source: external-secrets/templates/crds/fake.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: fakes.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - fake
+    kind: Fake
+    listKind: FakeList
+    plural: fakes
+    shortNames:
+      - fake
+    singular: fake
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Fake generator is used for testing. It lets you define
+            a static set of credentials that is always returned.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FakeSpec contains the static data.
+              properties:
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters VDS based on this property
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Data defines the static data returned
+                    by this generator.
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: "default"
+          path: /convert
+---
+# Source: external-secrets/templates/crds/gcraccesstoken.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: gcraccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - gcraccesstoken
+    kind: GCRAccessToken
+    listKind: GCRAccessTokenList
+    plural: gcraccesstokens
+    shortNames:
+      - gcraccesstoken
+    singular: gcraccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GCRAccessToken generates an GCP access token
+            that can be used to authenticate with GCR.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                auth:
+                  description: Auth defines the means for authenticating with GCP
+                  properties:
+                    secretRef:
+                      properties:
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          type: object
+                      type: object
+                    workloadIdentity:
+                      properties:
+                        clusterLocation:
+                          type: string
+                        clusterName:
+                          type: string
+                        clusterProjectID:
+                          type: string
+                        serviceAccountRef:
+                          description: A reference to a ServiceAccount resource.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - clusterLocation
+                        - clusterName
+                        - serviceAccountRef
+                      type: object
+                  type: object
+                projectID:
+                  description: ProjectID defines which project to use to authenticate with
+                  type: string
+              required:
+                - auth
+                - projectID
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: "default"
+          path: /convert
+---
+# Source: external-secrets/templates/crds/githubaccesstoken.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: githubaccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - githubaccesstoken
+    kind: GithubAccessToken
+    listKind: GithubAccessTokenList
+    plural: githubaccesstokens
+    shortNames:
+      - githubaccesstoken
+    singular: githubaccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GithubAccessToken generates ghs_ accessToken
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                appID:
+                  type: string
+                auth:
+                  description: Auth configures how ESO authenticates with a Github instance.
+                  properties:
+                    privatKey:
+                      properties:
+                        secretRef:
+                          description: |-
+                            A reference to a specific 'key' within a Secret resource,
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
+                                defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
+                                to the namespace of the referent.
+                              type: string
+                          type: object
+                      required:
+                        - secretRef
+                      type: object
+                  required:
+                    - privatKey
+                  type: object
+                installID:
+                  type: string
+                url:
+                  description: URL configures the Github instance URL. Defaults to https://github.com/.
+                  type: string
+              required:
+                - appID
+                - auth
+                - installID
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: "default"
+          path: /convert
+---
+# Source: external-secrets/templates/crds/password.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: passwords.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - password
+    kind: Password
+    listKind: PasswordList
+    plural: passwords
+    shortNames:
+      - password
+    singular: password
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Password generates a random password based on the
+            configuration parameters in spec.
+            You can specify the length, characterset and other attributes.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PasswordSpec controls the behavior of the password generator.
+              properties:
+                allowRepeat:
+                  default: false
+                  description: set AllowRepeat to true to allow repeating characters.
+                  type: boolean
+                digits:
+                  description: |-
+                    Digits specifies the number of digits in the generated
+                    password. If omitted it defaults to 25% of the length of the password
+                  type: integer
+                length:
+                  default: 24
+                  description: |-
+                    Length of the password to be generated.
+                    Defaults to 24
+                  type: integer
+                noUpper:
+                  default: false
+                  description: Set NoUpper to disable uppercase characters
+                  type: boolean
+                symbolCharacters:
+                  description: |-
+                    SymbolCharacters specifies the special characters that should be used
+                    in the generated password.
+                  type: string
+                symbols:
+                  description: |-
+                    Symbols specifies the number of symbol characters in the generated
+                    password. If omitted it defaults to 25% of the length of the password
+                  type: integer
+              required:
+                - allowRepeat
+                - length
+                - noUpper
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+        - v1
+      clientConfig:
+        service:
+          name: external-secrets-webhook
+          namespace: "default"
+          path: /convert
+---
+# Source: external-secrets/templates/crds/pushsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -6188,10 +6812,11 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
 ---
+# Source: external-secrets/templates/crds/secretstore.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -10350,771 +10975,11 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: acraccesstokens.generators.external-secrets.io
-spec:
-  group: generators.external-secrets.io
-  names:
-    categories:
-      - acraccesstoken
-    kind: ACRAccessToken
-    listKind: ACRAccessTokenList
-    plural: acraccesstokens
-    shortNames:
-      - acraccesstoken
-    singular: acraccesstoken
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            ACRAccessToken returns a Azure Container Registry token
-            that can be used for pushing/pulling images.
-            Note: by default it will return an ACR Refresh Token with full access
-            (depending on the identity).
-            This can be scoped down to the repository level using .spec.scope.
-            In case scope is defined it will return an ACR Access Token.
-
-
-            See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                ACRAccessTokenSpec defines how to generate the access token
-                e.g. how to authenticate and which registry to use.
-                see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview
-              properties:
-                auth:
-                  properties:
-                    managedIdentity:
-                      description: ManagedIdentity uses Azure Managed Identity to authenticate with Azure.
-                      properties:
-                        identityId:
-                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
-                          type: string
-                      type: object
-                    servicePrincipal:
-                      description: ServicePrincipal uses Azure Service Principal credentials to authenticate with Azure.
-                      properties:
-                        secretRef:
-                          description: |-
-                            Configuration used to authenticate with Azure using static
-                            credentials stored in a Kind=Secret.
-                          properties:
-                            clientId:
-                              description: The Azure clientId of the service principle used for authentication.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                    defaulted, in others it may be required.
-                                  type: string
-                                name:
-                                  description: The name of the Secret resource being referred to.
-                                  type: string
-                                namespace:
-                                  description: |-
-                                    Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                    to the namespace of the referent.
-                                  type: string
-                              type: object
-                            clientSecret:
-                              description: The Azure ClientSecret of the service principle used for authentication.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                    defaulted, in others it may be required.
-                                  type: string
-                                name:
-                                  description: The name of the Secret resource being referred to.
-                                  type: string
-                                namespace:
-                                  description: |-
-                                    Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                    to the namespace of the referent.
-                                  type: string
-                              type: object
-                          type: object
-                      required:
-                        - secretRef
-                      type: object
-                    workloadIdentity:
-                      description: WorkloadIdentity uses Azure Workload Identity to authenticate with Azure.
-                      properties:
-                        serviceAccountRef:
-                          description: |-
-                            ServiceAccountRef specified the service account
-                            that should be used when authenticating with WorkloadIdentity.
-                          properties:
-                            audiences:
-                              description: |-
-                                Audience specifies the `aud` claim for the service account token
-                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                then this audiences will be appended to the list
-                              items:
-                                type: string
-                              type: array
-                            name:
-                              description: The name of the ServiceAccount resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                      type: object
-                  type: object
-                environmentType:
-                  default: PublicCloud
-                  description: |-
-                    EnvironmentType specifies the Azure cloud environment endpoints to use for
-                    connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
-                    The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
-                    PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
-                  enum:
-                    - PublicCloud
-                    - USGovernmentCloud
-                    - ChinaCloud
-                    - GermanCloud
-                  type: string
-                registry:
-                  description: |-
-                    the domain name of the ACR registry
-                    e.g. foobarexample.azurecr.io
-                  type: string
-                scope:
-                  description: |-
-                    Define the scope for the access token, e.g. pull/push access for a repository.
-                    if not provided it will return a refresh token that has full scope.
-                    Note: you need to pin it down to the repository level, there is no wildcard available.
-
-
-                    examples:
-                    repository:my-repository:pull,push
-                    repository:my-repository:pull
-
-
-                    see docs for details: https://docs.docker.com/registry/spec/auth/scope/
-                  type: string
-                tenantId:
-                  description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
-                  type: string
-              required:
-                - auth
-                - registry
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: ecrauthorizationtokens.generators.external-secrets.io
-spec:
-  group: generators.external-secrets.io
-  names:
-    categories:
-      - ecrauthorizationtoken
-    kind: ECRAuthorizationToken
-    listKind: ECRAuthorizationTokenList
-    plural: ecrauthorizationtokens
-    shortNames:
-      - ecrauthorizationtoken
-    singular: ecrauthorizationtoken
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            ECRAuthorizationTokenSpec uses the GetAuthorizationToken API to retrieve an
-            authorization token.
-            The authorization token is valid for 12 hours.
-            The authorizationToken returned is a base64 encoded string that can be decoded
-            and used in a docker login command to authenticate to a registry.
-            For more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth) in the Amazon Elastic Container Registry User Guide.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                auth:
-                  description: Auth defines how to authenticate with AWS
-                  properties:
-                    jwt:
-                      description: Authenticate against AWS using service account tokens.
-                      properties:
-                        serviceAccountRef:
-                          description: A reference to a ServiceAccount resource.
-                          properties:
-                            audiences:
-                              description: |-
-                                Audience specifies the `aud` claim for the service account token
-                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                then this audiences will be appended to the list
-                              items:
-                                type: string
-                              type: array
-                            name:
-                              description: The name of the ServiceAccount resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                      type: object
-                    secretRef:
-                      description: |-
-                        AWSAuthSecretRef holds secret references for AWS credentials
-                        both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
-                      properties:
-                        accessKeyIDSecretRef:
-                          description: The AccessKeyID is used for authentication
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                defaulted, in others it may be required.
-                              type: string
-                            name:
-                              description: The name of the Secret resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          type: object
-                        secretAccessKeySecretRef:
-                          description: The SecretAccessKey is used for authentication
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                defaulted, in others it may be required.
-                              type: string
-                            name:
-                              description: The name of the Secret resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          type: object
-                        sessionTokenSecretRef:
-                          description: |-
-                            The SessionToken used for authentication
-                            This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
-                            see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                defaulted, in others it may be required.
-                              type: string
-                            name:
-                              description: The name of the Secret resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-                region:
-                  description: Region specifies the region to operate in.
-                  type: string
-                role:
-                  description: |-
-                    You can assume a role before making calls to the
-                    desired AWS service.
-                  type: string
-              required:
-                - region
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: fakes.generators.external-secrets.io
-spec:
-  group: generators.external-secrets.io
-  names:
-    categories:
-      - fake
-    kind: Fake
-    listKind: FakeList
-    plural: fakes
-    shortNames:
-      - fake
-    singular: fake
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            Fake generator is used for testing. It lets you define
-            a static set of credentials that is always returned.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: FakeSpec contains the static data.
-              properties:
-                controller:
-                  description: |-
-                    Used to select the correct ESO controller (think: ingress.ingressClassName)
-                    The ESO controller is instantiated with a specific controller name and filters VDS based on this property
-                  type: string
-                data:
-                  additionalProperties:
-                    type: string
-                  description: |-
-                    Data defines the static data returned
-                    by this generator.
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: gcraccesstokens.generators.external-secrets.io
-spec:
-  group: generators.external-secrets.io
-  names:
-    categories:
-      - gcraccesstoken
-    kind: GCRAccessToken
-    listKind: GCRAccessTokenList
-    plural: gcraccesstokens
-    shortNames:
-      - gcraccesstoken
-    singular: gcraccesstoken
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            GCRAccessToken generates an GCP access token
-            that can be used to authenticate with GCR.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                auth:
-                  description: Auth defines the means for authenticating with GCP
-                  properties:
-                    secretRef:
-                      properties:
-                        secretAccessKeySecretRef:
-                          description: The SecretAccessKey is used for authentication
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                defaulted, in others it may be required.
-                              type: string
-                            name:
-                              description: The name of the Secret resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          type: object
-                      type: object
-                    workloadIdentity:
-                      properties:
-                        clusterLocation:
-                          type: string
-                        clusterName:
-                          type: string
-                        clusterProjectID:
-                          type: string
-                        serviceAccountRef:
-                          description: A reference to a ServiceAccount resource.
-                          properties:
-                            audiences:
-                              description: |-
-                                Audience specifies the `aud` claim for the service account token
-                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
-                                then this audiences will be appended to the list
-                              items:
-                                type: string
-                              type: array
-                            name:
-                              description: The name of the ServiceAccount resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          required:
-                            - name
-                          type: object
-                      required:
-                        - clusterLocation
-                        - clusterName
-                        - serviceAccountRef
-                      type: object
-                  type: object
-                projectID:
-                  description: ProjectID defines which project to use to authenticate with
-                  type: string
-              required:
-                - auth
-                - projectID
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: githubaccesstokens.generators.external-secrets.io
-spec:
-  group: generators.external-secrets.io
-  names:
-    categories:
-      - githubaccesstoken
-    kind: GithubAccessToken
-    listKind: GithubAccessTokenList
-    plural: githubaccesstokens
-    shortNames:
-      - githubaccesstoken
-    singular: githubaccesstoken
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: GithubAccessToken generates ghs_ accessToken
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                appID:
-                  type: string
-                auth:
-                  description: Auth configures how ESO authenticates with a Github instance.
-                  properties:
-                    privatKey:
-                      properties:
-                        secretRef:
-                          description: |-
-                            A reference to a specific 'key' within a Secret resource,
-                            In some instances, `key` is a required field.
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be
-                                defaulted, in others it may be required.
-                              type: string
-                            name:
-                              description: The name of the Secret resource being referred to.
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the resource being referred to. Ignored if referent is not cluster-scoped. cluster-scoped defaults
-                                to the namespace of the referent.
-                              type: string
-                          type: object
-                      required:
-                        - secretRef
-                      type: object
-                  required:
-                    - privatKey
-                  type: object
-                installID:
-                  type: string
-                url:
-                  description: URL configures the Github instance URL. Defaults to https://github.com/.
-                  type: string
-              required:
-                - appID
-                - auth
-                - installID
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: passwords.generators.external-secrets.io
-spec:
-  group: generators.external-secrets.io
-  names:
-    categories:
-      - password
-    kind: Password
-    listKind: PasswordList
-    plural: passwords
-    shortNames:
-      - password
-    singular: password
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            Password generates a random password based on the
-            configuration parameters in spec.
-            You can specify the length, characterset and other attributes.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PasswordSpec controls the behavior of the password generator.
-              properties:
-                allowRepeat:
-                  default: false
-                  description: set AllowRepeat to true to allow repeating characters.
-                  type: boolean
-                digits:
-                  description: |-
-                    Digits specifies the number of digits in the generated
-                    password. If omitted it defaults to 25% of the length of the password
-                  type: integer
-                length:
-                  default: 24
-                  description: |-
-                    Length of the password to be generated.
-                    Defaults to 24
-                  type: integer
-                noUpper:
-                  default: false
-                  description: Set NoUpper to disable uppercase characters
-                  type: boolean
-                symbolCharacters:
-                  description: |-
-                    SymbolCharacters specifies the special characters that should be used
-                    in the generated password.
-                  type: string
-                symbols:
-                  description: |-
-                    Symbols specifies the number of symbol characters in the generated
-                    password. If omitted it defaults to 25% of the length of the password
-                  type: integer
-              required:
-                - allowRepeat
-                - length
-                - noUpper
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-        - v1
-      clientConfig:
-        service:
-          name: kubernetes
-          namespace: default
-          path: /convert
----
+# Source: external-secrets/templates/crds/vaultdynamicsecret.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -11802,10 +11667,11 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
 ---
+# Source: external-secrets/templates/crds/webhook.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -11948,6 +11814,689 @@ spec:
         - v1
       clientConfig:
         service:
-          name: kubernetes
-          namespace: default
+          name: external-secrets-webhook
+          namespace: "default"
           path: /convert
+---
+# Source: external-secrets/templates/cert-controller-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-cert-controller
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - "apiextensions.k8s.io"
+    resources:
+    - "customresourcedefinitions"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - "admissionregistration.k8s.io"
+    resources:
+    - "validatingwebhookconfigurations"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "endpoints"
+    verbs:
+    - "list"
+    - "get"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "events"
+    verbs:
+    - "create"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - "leases"
+    verbs:
+    - "get"
+    - "create"
+    - "update"
+    - "patch"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-controller
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "secretstores"
+    - "clustersecretstores"
+    - "externalsecrets"
+    - "clusterexternalsecrets"
+    - "pushsecrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    - "externalsecrets/status"
+    - "externalsecrets/finalizers"
+    - "secretstores"
+    - "secretstores/status"
+    - "secretstores/finalizers"
+    - "clustersecretstores"
+    - "clustersecretstores/status"
+    - "clustersecretstores/finalizers"
+    - "clusterexternalsecrets"
+    - "clusterexternalsecrets/status"
+    - "clusterexternalsecrets/finalizers"
+    - "pushsecrets"
+    - "pushsecrets/status"
+    - "pushsecrets/finalizers"
+    verbs:
+    - "update"
+    - "patch"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "githubaccesstokens"
+    - "passwords"
+    - "vaultdynamicsecrets"
+    - "webhooks"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts"
+    - "namespaces"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "serviceaccounts/token"
+    verbs:
+    - "create"
+  - apiGroups:
+    - ""
+    resources:
+    - "events"
+    verbs:
+    - "create"
+    - "patch"
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    verbs:
+    - "create"
+    - "update"
+    - "delete"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-view
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - "external-secrets.io"
+    resources:
+      - "externalsecrets"
+      - "secretstores"
+      - "clustersecretstores"
+      - "pushsecrets"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "githubaccesstokens"
+    - "passwords"
+    - "vaultdynamicsecrets"
+    - "webhooks"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-edit
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - "external-secrets.io"
+    resources:
+      - "externalsecrets"
+      - "secretstores"
+      - "clustersecretstores"
+      - "pushsecrets"
+    verbs:
+      - "create"
+      - "delete"
+      - "deletecollection"
+      - "patch"
+      - "update"
+  - apiGroups:
+    - "generators.external-secrets.io"
+    resources:
+    - "acraccesstokens"
+    - "ecrauthorizationtokens"
+    - "fakes"
+    - "gcraccesstokens"
+    - "githubaccesstokens"
+    - "passwords"
+    - "vaultdynamicsecrets"
+    - "webhooks"
+    verbs:
+      - "create"
+      - "delete"
+      - "deletecollection"
+      - "patch"
+      - "update"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-servicebindings
+  labels:
+    servicebinding.io/controller: "true"
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "externalsecrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+---
+# Source: external-secrets/templates/cert-controller-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-cert-controller
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-cert-controller
+subjects:
+  - name: external-secrets-cert-controller
+    namespace: default
+    kind: ServiceAccount
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-controller
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-controller
+subjects:
+  - name: external-secrets
+    namespace: default
+    kind: ServiceAccount
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: external-secrets-leaderelection
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    resourceNames:
+    - "external-secrets-controller"
+    verbs:
+    - "get"
+    - "update"
+    - "patch"
+  - apiGroups:
+    - ""
+    resources:
+    - "configmaps"
+    verbs:
+    - "create"
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - "leases"
+    verbs:
+    - "get"
+    - "create"
+    - "update"
+    - "patch"
+---
+# Source: external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: external-secrets-leaderelection
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-secrets-leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: default
+---
+# Source: external-secrets/templates/webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-secrets-webhook
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+    external-secrets.io/component: webhook
+spec:
+  type: ClusterIP
+  ports:
+  - port: 443
+    targetPort: 10250
+    protocol: TCP
+    name: webhook
+  selector:
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets
+---
+# Source: external-secrets/templates/cert-controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets-cert-controller
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-cert-controller
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-cert-controller
+      app.kubernetes.io/instance: external-secrets
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: external-secrets-v0.9.16
+        app.kubernetes.io/name: external-secrets-cert-controller
+        app.kubernetes.io/instance: external-secrets
+        app.kubernetes.io/version: "v0.9.16"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: external-secrets-cert-controller
+      automountServiceAccountToken: true
+      hostNetwork: false
+      containers:
+        - name: cert-controller
+          requests:
+            memory: "512m"
+            cpu: "250m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: ghcr.io/external-secrets/external-secrets:v0.9.16
+          imagePullPolicy: IfNotPresent
+          args:
+          - certcontroller
+          - --crd-requeue-interval=5m
+          - --service-name=external-secrets-webhook
+          - --service-namespace=default
+          - --secret-name=external-secrets-webhook
+          - --secret-namespace=default
+          - --metrics-addr=:8080
+          - --healthz-addr=:8081
+          
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: metrics
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /readyz
+            initialDelaySeconds: 20
+            periodSeconds: 5
+---
+# Source: external-secrets/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets
+      app.kubernetes.io/instance: external-secrets
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: external-secrets-v0.9.16
+        app.kubernetes.io/name: external-secrets
+        app.kubernetes.io/instance: external-secrets
+        app.kubernetes.io/version: "v0.9.16"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: external-secrets
+      automountServiceAccountToken: true
+      hostNetwork: false
+      containers:
+        - name: external-secrets
+          requests:
+            memory: "512m"
+            cpu: "250m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: ghcr.io/external-secrets/external-secrets:v0.9.16
+          imagePullPolicy: IfNotPresent
+          args:
+          - --concurrent=1
+          - --metrics-addr=:8080
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+---
+# Source: external-secrets/templates/webhook-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-secrets-webhook
+  namespace: default
+  labels:
+    helm.sh/chart: external-secrets-v0.9.16
+    app.kubernetes.io/name: external-secrets-webhook
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/version: "v0.9.16"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-secrets-webhook
+      app.kubernetes.io/instance: external-secrets
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: external-secrets-v0.9.16
+        app.kubernetes.io/name: external-secrets-webhook
+        app.kubernetes.io/instance: external-secrets
+        app.kubernetes.io/version: "v0.9.16"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      hostNetwork: false
+      serviceAccountName: external-secrets-webhook
+      automountServiceAccountToken: true
+      containers:
+        - name: webhook
+          requests:
+            memory: "512m"
+            cpu: "250m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          image: ghcr.io/external-secrets/external-secrets:v0.9.16
+          imagePullPolicy: IfNotPresent
+          args:
+          - webhook
+          - --port=10250
+          - --dns-name=external-secrets-webhook.default.svc
+          - --cert-dir=/tmp/certs
+          - --check-interval=5m
+          - --metrics-addr=:8080
+          - --healthz-addr=:8081
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: metrics
+            - containerPort: 10250
+              protocol: TCP
+              name: webhook
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /readyz
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          volumeMounts:
+            - name: certs
+              mountPath: /tmp/certs
+              readOnly: true
+      volumes:
+        - name: certs
+          secret:
+            secretName: external-secrets-webhook
+---
+# Source: external-secrets/templates/validatingwebhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: secretstore-validate
+  labels:
+    external-secrets.io/component: webhook
+webhooks:
+- name: "validate.secretstore.external-secrets.io"
+  rules:
+  - apiGroups:   ["external-secrets.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["secretstores"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: default
+      name: external-secrets-webhook
+      path: /validate-external-secrets-io-v1beta1-secretstore
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+
+- name: "validate.clustersecretstore.external-secrets.io"
+  rules:
+  - apiGroups:   ["external-secrets.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["clustersecretstores"]
+    scope:       "Cluster"
+  clientConfig:
+    service:
+      namespace: default
+      name: external-secrets-webhook
+      path: /validate-external-secrets-io-v1beta1-clustersecretstore
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+---
+# Source: external-secrets/templates/validatingwebhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: externalsecret-validate
+  labels:
+    external-secrets.io/component: webhook
+webhooks:
+- name: "validate.externalsecret.external-secrets.io"
+  rules:
+  - apiGroups:   ["external-secrets.io"]
+    apiVersions: ["v1beta1"]
+    operations:  ["CREATE", "UPDATE", "DELETE"]
+    resources:   ["externalsecrets"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: default
+      name: external-secrets-webhook
+      path: /validate-external-secrets-io-v1beta1-externalsecret
+  admissionReviewVersions: ["v1", "v1beta1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail

--- a/kubernetes/mattermost/external-secrets-operator.yml
+++ b/kubernetes/mattermost/external-secrets-operator.yml
@@ -12262,9 +12262,10 @@ spec:
       hostNetwork: false
       containers:
         - name: cert-controller
-          requests:
-            memory: "512m"
-            cpu: "250m"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -12331,9 +12332,10 @@ spec:
       hostNetwork: false
       containers:
         - name: external-secrets
-          requests:
-            memory: "512m"
-            cpu: "250m"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -12353,10 +12355,6 @@ spec:
             - containerPort: 8080
               protocol: TCP
               name: metrics
-          resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
 ---
 # Source: external-secrets/templates/webhook-deployment.yaml
 apiVersion: apps/v1
@@ -12391,9 +12389,10 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: webhook
-          requests:
-            memory: "512m"
-            cpu: "250m"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
- #31 で追加したexternal secrets operatorにdeploymentがなく、機能していなかったので https://github.com/external-secrets/external-secrets/releases/tag/v0.9.16 の release にある external-secrets.yaml と差し替え