### PR TITLE
[修正] secretAccessorの紐づけ先をexternal secret operatorのSAに変更

### DIFF
--- a/terraform/iam/iam.tf
+++ b/terraform/iam/iam.tf
@@ -33,8 +33,8 @@ locals {
     },
     {
       gsa           = "${google_service_account.wi-secret-mattermost-primary.name}",
-      ksa_namespace = "mattermost",
-      ksa_name      = "secret-mattermost-primary"
+      ksa_namespace = "default",
+      ksa_name      = "external-secrets"
     }
   ]
 }


### PR DESCRIPTION
#35 の修正漏れ