### PR TITLE
[修正] podのstatusを更新できなくてmattermostが再起動を繰り返していたため修正

### DIFF
--- a/terraform/iam/iam.tf
+++ b/terraform/iam/iam.tf
@@ -124,6 +124,7 @@ resource "google_project_iam_binding" "secret-manager" {
 }
 
 resource "google_project_iam_binding" "pod_status_updater_binding" {
+  project = "mitou-jr"
   role = google_project_iam_custom_role.pod_status_updater.id
   members = [
     "serviceAccount:${google_service_account.wi-mattermost-primary.email}",

--- a/terraform/iam/iam.tf
+++ b/terraform/iam/iam.tf
@@ -125,7 +125,7 @@ resource "google_project_iam_binding" "secret-manager" {
 
 resource "google_project_iam_binding" "pod_status_updater_binding" {
   project = "mitou-jr"
-  role = google_project_iam_custom_role.pod_status_updater.id
+  role    = google_project_iam_custom_role.pod_status_updater.id
   members = [
     "serviceAccount:${google_service_account.wi-mattermost-primary.email}",
   ]

--- a/terraform/iam/iam.tf
+++ b/terraform/iam/iam.tf
@@ -122,3 +122,10 @@ resource "google_project_iam_binding" "secret-manager" {
     "serviceAccount:${google_service_account.wi-secret-mattermost-primary.email}",
   ]
 }
+
+resource "google_project_iam_binding" "pod_status_updater_binding" {
+  role = google_project_iam_custom_role.pod_status_updater.id
+  members = [
+    "serviceAccount:${google_service_account.wi-mattermost-primary.email}",
+  ]
+}

--- a/terraform/iam/role.tf
+++ b/terraform/iam/role.tf
@@ -28,3 +28,10 @@ resource "google_project_iam_custom_role" "tfplanner" {
     "dns.responsePolicyRules.list",
   ]
 }
+
+resource "google_project_iam_custom_role" "pod_status_updater" {
+  role_id     = "podStatusUpdater"
+  title       = "Pod Status Updater"
+  description = "Allows updating pod status"
+  permissions = ["container.pods.updateStatus"]
+}


### PR DESCRIPTION
- `container.pods.updateStatus`を追加した`pod_status_updater`ロールを追加
- `mattermost-primary`に`pod_status_updater`を割り当て