### PR TITLE
[更新] mattermostを9.7に更新

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -39,7 +39,7 @@ spec:
               mountPath: /secret
       containers:
       - name: mattermost
-        image: mattermost/mattermost-team-edition:release-9.6
+        image: mattermost/mattermost-team-edition:9.7
         imagePullPolicy: Always
         env:
           - name: MATTERMOST_TOKEN


### PR DESCRIPTION
`mattermost/mattermost-team-edition:release-9.7`を用いるとなぜか`9.7.4-rc1`が入るので`mattermost/mattermost-team-edition:9.7`を使用しています