### PR TITLE
エンタープライズ版イメージへの移行

### DIFF
--- a/kubernetes/mattermost/external-secret.yml
+++ b/kubernetes/mattermost/external-secret.yml
@@ -19,6 +19,24 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: gcp-secret-mattermost-license
+  namespace: mattermost
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcp-secret-store
+  target:
+    name: gcp-secret-license
+    creationPolicy: Owner
+  data:
+  - secretKey: mitoujr.mattermost-license
+    remoteRef:
+      key: mattermost-license
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: gcp-secret-mattermost-env
   namespace: mattermost
 spec:

--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -36,7 +36,7 @@ spec:
             - name: secret
               mountPath: /secret
         - name: bleve-indexer
-          image: mattermost/mattermost-team-edition:9.7
+          image: mattermost/mattermost-enterprise-edition:9.7
           imagePullPolicy: Always
           env:
             - name: MATTERMOST_TOKEN
@@ -67,7 +67,7 @@ spec:
               mountPath: /mattermost/data/
       containers:
       - name: mattermost
-        image: mattermost/mattermost-team-edition:9.7
+        image: mattermost/mattermost-enterprise-edition:9.7
         imagePullPolicy: Always
         ports:
         - name: http

--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -29,12 +29,15 @@ spec:
           command: ["/bin/sh","-c"]
           args:
             - cp /secret/config.json /config/config.json
-              && chown 2000:2000 /config/config.json
+              && cp /license/mitoujr.mattermost-license /config/mitoujr.mattermost-license
+              && chown 2000:2000 /config/*
           volumeMounts:
             - name: config
               mountPath: /config
             - name: secret
               mountPath: /secret
+            - name: license
+              mountPath: /license
         - name: bleve-indexer
           image: mattermost/mattermost-enterprise-edition:9.7
           imagePullPolicy: Always
@@ -121,3 +124,6 @@ spec:
         - name: secret
           secret:
             secretName: gcp-secret-config
+        - name: license
+          secret:
+            secretName: gcp-secret-license


### PR DESCRIPTION
- ライセンスファイル
  - GCPのシークレット `mattermost-license`に格納(済)
  - 配置場所: `/mattermost/config/mitoujr.mattermost-license`
- コンフィグファイル
  - licenseファイルの配置パスを追記(済)
    - ref: https://docs.mattermost.com/configure/environment-configuration-settings.html#web-licensefilelocation 
    - 項目にエンプラのみ表記があったのでteam版にコンフィグが反映されても問題ないと判断
