### PR TITLE
[更新] mattermost を v10.2 に更新

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -51,7 +51,7 @@ spec:
             - name: license
               mountPath: /license
         - name: bleve-indexer
-          image: mattermost/mattermost-enterprise-edition:release-9.11
+          image: mattermost/mattermost-enterprise-edition:release-10.2
           imagePullPolicy: Always
           env:
             - name: MATTERMOST_TOKEN


### PR DESCRIPTION
- release-10/release-10.3はpre releaseな10.3系になってしまうので10.2で固定
- 10.2系最新10.2.1はreleaseになっている