### PR TITLE
Rollback mattermost image from 10.10 to 10.9

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -51,7 +51,7 @@ spec:
             - name: license
               mountPath: /license
         - name: bleve-indexer
-          image: mattermost/mattermost-enterprise-edition:release-10.10
+          image: mattermost/mattermost-enterprise-edition:release-10.9
           imagePullPolicy: Always
           env:
             - name: MATTERMOST_TOKEN
@@ -73,7 +73,7 @@ spec:
               mountPath: /mattermost/data/
       containers:
       - name: mattermost
-        image: mattermost/mattermost-enterprise-edition:release-10.10
+        image: mattermost/mattermost-enterprise-edition:release-10.9
         imagePullPolicy: Always
         ports:
         - name: http


### PR DESCRIPTION
Mattermost image no longer includes shell and it leads `blave-indexer` initContainer failing.