### PR TITLE
fix: startup probeがコケていたので修正

### DIFF
--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -72,7 +72,7 @@ spec:
           periodSeconds: 5
           failureThreshold: 4
           httpGet:
-            path:  /api/v4/system/ping
+            path: /api/v4/system/ping
             port: http
         livenessProbe:
           initialDelaySeconds: 600
@@ -83,16 +83,10 @@ spec:
             path:  /api/v4/system/ping
             port: http
         startupProbe:
-          exec:
-            command:
-              - /bin/sh
-              - -c
-              - |
-                # Check if Mattermost is ready
-                wget -q --spider --timeout=5 http://localhost:8000/api/v4/system/ping || exit 1
-                # Check if bleve indexing is complete
-                test -f /shared/bleve-index-complete || exit 1
-          failureThreshold: 360
+          httpGet:
+            path: /api/v4/system/ping
+            port: http
+          failureThreshold: 60
           periodSeconds: 10
         volumeMounts:
           - name: config


### PR DESCRIPTION
- mattermost上でコマンドが実行できない
- そもそもindexer側がreadyにならなければmattermostにトラフィックは流れない

ことから、mattermost側でindexの完了を確認するのを辞めました