### PR TITLE
active/standby 化（外部 active-standby-operator を利用）

### DIFF
--- a/.github/workflows/k8s-deploy.yml
+++ b/.github/workflows/k8s-deploy.yml
@@ -43,5 +43,43 @@ jobs:
       - name: Deploy
         # if: env. GIT_DIFF_FILTERED
         run: |-
-          kubectl apply -f ./kubernetes/mattermost/
+          # Ordering matters for the active/standby cutover: the narrowed Service
+          # selector (app=mattermost,mm-role=active) must NOT take effect until the
+          # operator has labelled a pod, otherwise the NEG would momentarily have
+          # zero endpoints and the LB would 502.
+          #
+          # 1) Apply everything in the mattermost dir EXCEPT the Service. This
+          #    creates/updates the namespace, RBAC and Deployment while leaving the
+          #    currently-serving Service selector untouched.
+          for f in ./kubernetes/mattermost/*.yml ./kubernetes/mattermost/*.yaml; do
+            [ -e "$f" ] || continue
+            [ "$(basename "$f")" = "service.yml" ] && continue
+            kubectl apply -f "$f"
+          done
+
+          # 2) Bring up the operator; it assigns the mm-role=active label.
+          kubectl apply -f ./kubernetes/operator/
+
+          # 3) Wait until an active pod exists before relying on the narrowed
+          #    selector (protects the very first cutover; a no-op afterwards). If
+          #    no active pod appears (e.g. the operator image has not been pushed
+          #    yet), FAIL the job WITHOUT narrowing the Service: the existing broad
+          #    selector keeps both pods serving, so there is no outage — just retry
+          #    once the operator is healthy.
+          echo "waiting for an active mattermost pod..."
+          active_present=false
+          for i in $(seq 1 40); do
+            if kubectl -n mattermost get pods -l app=mattermost,mm-role=active \
+                 --field-selector=status.phase=Running -o name | grep -q .; then
+              echo "active pod present"; active_present=true; break
+            fi
+            sleep 3
+          done
+          if [ "$active_present" != "true" ]; then
+            echo "::error::no active mattermost pod after timeout; leaving Service selector unchanged"
+            exit 1
+          fi
+
+          # 4) Now it is safe to narrow the Service, then roll the workload.
+          kubectl apply -f ./kubernetes/mattermost/service.yml
           kubectl -n mattermost rollout restart deployment mattermost

--- a/kubernetes/mattermost/mattermost.yml
+++ b/kubernetes/mattermost/mattermost.yml
@@ -67,12 +67,19 @@ spec:
             cpu: 1000m
             memory: 4Gi
             ephemeral-storage: 4096Mi
+        # Readiness uses the deep ping (?get_server_status=true), which returns
+        # non-200 when the DB or filestore is stalled. A "Running but effectively
+        # dead" pod then flips to NotReady and GKE removes it from the NEG.
+        # Liveness and startup deliberately stay on the shallow ping: tying
+        # liveness to the DB would let a transient DB outage restart every pod
+        # (amplifying a DB blip into a cluster-wide CrashLoop). DB health belongs
+        # in readiness (stop traffic) and the operator probe (fail over) only.
         readinessProbe:
           timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 4
           httpGet:
-            path: /api/v4/system/ping
+            path: /api/v4/system/ping?get_server_status=true
             port: http
         livenessProbe:
           initialDelaySeconds: 600

--- a/kubernetes/mattermost/service.yml
+++ b/kubernetes/mattermost/service.yml
@@ -8,8 +8,12 @@ metadata:
     cloud.google.com/backend-config: '{"default": "mattermost-backend-service"}'
 spec:
   type: ClusterIP
+  # active/standby: the NEG (and therefore the GCP LB) only sees the single pod
+  # that the active-standby-operator has labelled mm-role=active. The standby pod
+  # runs mattermost but carries no mm-role label, so it is excluded from the NEG.
   selector:
     app: mattermost
+    mm-role: active
   ports:
   - protocol: TCP
     port: 80

--- a/kubernetes/operator/deployment.yml
+++ b/kubernetes/operator/deployment.yml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mm-active-standby-operator
+  namespace: mattermost
+  labels:
+    app: mm-active-standby-operator
+spec:
+  # Single instance, Recreate strategy: there must never be two operators making
+  # conflicting label decisions at the same time. No leader election needed.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mm-active-standby-operator
+  template:
+    metadata:
+      labels:
+        app: mm-active-standby-operator
+    spec:
+      serviceAccountName: mm-active-standby-operator
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: operator
+          # Generic operator, published from github.com/mitou/kubernetes-active-standby-operator.
+          # NOTE: the GHCR package must be public (or an imagePullSecret added)
+          # for GKE to pull it. Pin to a released tag instead of :latest once cut.
+          image: ghcr.io/mitou/kubernetes-active-standby-operator:latest
+          imagePullPolicy: Always
+          env:
+            - name: NAMESPACE
+              value: mattermost
+            - name: POD_LABEL_SELECTOR
+              value: app=mattermost
+            - name: ROLE_LABEL_KEY
+              value: mm-role
+            - name: ROLE_LABEL_VALUE
+              value: active
+            - name: SERVICE_NAME
+              value: mattermost
+            - name: POD_PORT
+              value: "8000"
+            - name: PROBE_PATH
+              value: /api/v4/system/ping?get_server_status=true
+            # The deep ping returns database_status when healthy and a non-2xx
+            # when the DB is down; this substring guards a 200-but-degraded case.
+            - name: PROBE_EXPECT_BODY
+              value: '"database_status":"OK"'
+            - name: PROBE_TIMEOUT
+              value: 3s
+            - name: PROBE_LATENCY_BUDGET
+              value: 2s
+            - name: RECONCILE_INTERVAL
+              value: 5s
+            - name: FAILURE_THRESHOLD
+              value: "3"
+            - name: FAILOVER_COOLDOWN
+              value: 60s
+            - name: DELETE_STUCK_ACTIVE
+              value: "true"
+            - name: ENDPOINT_PROGRAM_WAIT
+              value: 30s
+            # Downward API: used as the involvedObject for namespace-level Events.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: health
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]

--- a/kubernetes/operator/rbac.yml
+++ b/kubernetes/operator/rbac.yml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mm-active-standby-operator
+  namespace: mattermost
+---
+# Namespaced Role: everything the operator touches lives in the mattermost
+# namespace, and it needs no GCP/Workload-Identity permissions (pure k8s API).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mm-active-standby-operator
+  namespace: mattermost
+rules:
+  # watch pods, patch the role label, delete a wedged active pod.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "patch", "delete"]
+  # confirm a freshly-promoted pod's endpoint is ready before demoting the old one.
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  # surface failovers / degraded states as Events for the existing monitoring.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mm-active-standby-operator
+  namespace: mattermost
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mm-active-standby-operator
+subjects:
+  - kind: ServiceAccount
+    name: mm-active-standby-operator
+    namespace: mattermost


### PR DESCRIPTION
## 背景

Mattermost を **active/active → active/standby** に変更します。クラスタリング無効（`ClusterSettings.Enable: false`）のまま 2 ノードを active/active で動かすと、ノード間で協調しないため次が起きます:

- 検索インデックス(bleve)の不整合（ノードローカル index）
- インメモリキャッシュの不整合
- WebSocket イベントの取りこぼし

常に **1 ノードだけが配信** する active/standby にしてこれらを解消します。Enterprise HA クラスタリングは有効化しません。

## 構成

- `Service` セレクタを `app=mattermost,mm-role=active` に絞り、NEG（GCP LB）には `mm-role=active` ラベルを持つ 1 Pod だけを載せる
- フェイルオーバー制御は汎用オペレータ **[mitou/kubernetes-active-standby-operator](https://github.com/mitou/kubernetes-active-standby-operator)**（GHCR イメージ）を利用。本リポジトリには設定マニフェスト（`kubernetes/operator/`）のみを置く
- ヘルスモデル: readiness を deep ping（`?get_server_status=true`、DB/filestore 停止で NotReady）化、**liveness は shallow ping 維持**（DB 障害の再起動増幅を回避）。オペレータが独自プローブ＋ヒステリシス＋クールダウンでフェイルオーバー、add-before-remove（EndpointSlice Ready 待ち）で無停止切替
- `PROBE_EXPECT_BODY='\"database_status\":\"OK\"'` で 200-but-degraded を追加ガード

## デプロイ順序（初回カットオーバー）

`k8s-deploy.yml` は **active ラベル付き Pod が出現するまで待ってから** Service を絞る順序にしてあります。出現しなければ Service を絞らずジョブを失敗させる（広いセレクタのまま＝無停止、再実行で回復）。

## ⚠️ 反映前の確認事項

- **GHCR パッケージの公開設定**: `ghcr.io/mitou/kubernetes-active-standby-operator` を public にする（または `imagePullSecret` を追加）。private のままだと GKE が pull 不可
- 実機で `ClusterSettings.Enable` を確認（standby も DB 接続のまま稼働するため、無効だと背景ジョブが二重実行され得る — ホットスタンバイ採用時の既知トレードオフ）
- bleve サイドカーの startupProbe が Pod Ready をゲートする点（再作成 standby の昇格遅延の可能性）

## テスト

オペレータ本体（ロジック/プローブのユニットテスト）は別リポジトリ側で green。本 PR は manifests/workflow の変更のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)